### PR TITLE
#10 - Add automatic module name to generated jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,6 @@ allprojects{
         propertiesFile file: file("${rootDir}/dependencies.properties")
 	}
 
-    group = 'org.starchartlabs.tempest'
-
     sourceCompatibility = "${javaVersion}"
 
     //Always download sources, to allow debugging, and use Eclipse containers for greater portability
@@ -53,6 +51,13 @@ subprojects{
             useDefaultListeners = true
         }
     }
+    
+    //Apply module naming to all projects
+    jar {
+		manifest {
+			attributes("Automatic-Module-Name": "${project.group}.${project.name  - 'alloy-'}".replaceAll("-", "."))
+		}
+	}
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
+# General library settings
+group=org.starchartlabs.alloy
+
 # Application Versions
 version=0.1.0-SNAPSHOT
 


### PR DESCRIPTION
The automatic module name manifest entry allows those experimenting with the Java 9 module system to more easily use the alloy libraries