### PR TITLE
Add implementation of a short-circuit capable Spliterator

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Add org.starchartlabs.alloy.core.collections.MoreSpliterators for streamlined and reduced boilerplate in relation to Java spliterator constructs
+- Addition of support for short-circuited spliterators via org.starchartlabs.alloy.core.collections.MoreSpliterators.shortCircuit
 
 ## [0.3.0]
 ### Added

--- a/alloy-core/build.gradle
+++ b/alloy-core/build.gradle
@@ -2,7 +2,8 @@ description = 'Basic utilities to streamline common Java operations'
 
 //Dependency versions managed in ${rootDir}/dependencies.properties
 dependencies {
-	compileOnly group: 'com.google.code.findbugs', name: 'jsr305'
+	compileOnly 'com.google.code.findbugs:jsr305'
 	
-	testCompile group: 'org.testng', name: 'testng'
+	testCompile 'org.testng:testng'
+    testCompile 'org.mockito:mockito-core'
 }

--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/MoreCollections.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/MoreCollections.java
@@ -20,7 +20,7 @@ import java.util.function.Supplier;
  * Provides methods for streamlining and reducing boilerplate in relation to operations related to Java collections
  *
  * @author romeara
- * @since 1.0.0
+ * @since 0.3.0
  */
 public final class MoreCollections {
 

--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/MoreSpliterators.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/MoreSpliterators.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.alloy.core.collections;
+
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
+/**
+ * Provides methods for streamlining and reducing boilerplate for operations related to Java {@link Spliterator}s
+ *
+ * @author romeara
+ * @since 0.4.0
+ */
+public final class MoreSpliterators {
+
+    /**
+     * Returns a spliterator which allows stopping traversal when the previously traversed elements meet criteria
+     * specified by a predicate. If the predicate condition is never met, the spliterator traverses as normal
+     *
+     * <p>
+     * The returned spliterator will have a sub-set of the characteristics of the original
+     *
+     * @param spliterator
+     *            Original spliterator which traverses elements until complete
+     * @param accumulator
+     *            Function which accepts a representation of previously traversed elements and the current element. If
+     *            no elements were previously traversed, the provided previous value will be an empty Optional. Must
+     *            return non-null
+     * @param completedPredicate
+     *            Predicate defining the conditions under which to cease traversal of the spliterator
+     * @param <T>
+     *            Representation supplied by the provided {@code spliterator}
+     * @param <A>
+     *            Representation of accumulated data from previously traversed rows
+     * @return A spliterator which allows short-circuiting traversal based on a predicate
+     * @since 0.4.0
+     */
+    public static <T, A> Spliterator<T> shortCircuit(Spliterator<T> spliterator,
+            BiFunction<Optional<A>, ? super T, A> accumulator, Predicate<A> completedPredicate) {
+        return new ShortCircuitSpliterator<>(spliterator, accumulator, completedPredicate);
+    }
+
+    private static class ShortCircuitSpliterator<T, A> implements Spliterator<T> {
+
+        private static final int SUPPORTED_CHARACTERISTICS = Spliterator.DISTINCT | Spliterator.IMMUTABLE
+                | Spliterator.NONNULL | Spliterator.ORDERED | Spliterator.SORTED;
+
+        private final Spliterator<T> spliterator;
+
+        private final Predicate<A> completedPredicate;
+
+        private final AccumulatingConsumer<T, A> consumer;
+
+        public ShortCircuitSpliterator(Spliterator<T> spliterator, BiFunction<Optional<A>, ? super T, A> accumulator,
+                Predicate<A> completedPredicate) {
+            this.spliterator = Objects.requireNonNull(spliterator);
+            this.completedPredicate = Objects.requireNonNull(completedPredicate);
+            this.consumer = new AccumulatingConsumer<>(accumulator);
+        }
+
+        @Override
+        public boolean tryAdvance(Consumer<? super T> action) {
+            boolean complete = consumer.getAccumulated()
+                    .map(completedPredicate::test)
+                    .orElse(false);
+
+            if (!complete) {
+                complete = !spliterator.tryAdvance(input -> consumer.accept(action, input));
+            }
+
+            return !complete;
+        }
+
+        @Override
+        public Spliterator<T> trySplit() {
+            // TODO romeara Not sure there is a good way to safely split this for parallel operation - for now, stick to
+            // the safer option
+            return null;
+        }
+
+        @Override
+        public long estimateSize() {
+            // There is no way to know when the condition will be met, so present the worst-case scenario (of "never
+            // short circuited") according to the underlying spliterator
+            return spliterator.estimateSize();
+        }
+
+        @Override
+        public int characteristics() {
+            // Certain characteristic behaviors do not persist once short-circuiting is applied
+            // For example, SIZED can no longer be guaranteed, as the traversal may complete before iterating over all
+            // underlying values
+            return SUPPORTED_CHARACTERISTICS & spliterator.characteristics();
+        }
+
+        // Expose information available in the supporting spliterator, allowing the "SORTED" characteristic to be
+        // supported if provided by the supporting spliterator
+        @Override
+        public Comparator<? super T> getComparator() {
+            return spliterator.getComparator();
+        }
+
+        private static class AccumulatingConsumer<T, A> {
+
+            private final BiFunction<Optional<A>, ? super T, A> accumulator;
+
+            private Optional<A> accumulated;
+
+            public AccumulatingConsumer(BiFunction<Optional<A>, ? super T, A> accumulator) {
+                this.accumulator = Objects.requireNonNull(accumulator);
+                this.accumulated = Optional.empty();
+            }
+
+            public void accept(Consumer<? super T> action, T input) {
+                action.accept(input);
+                accumulated = Optional.of(accumulator.apply(accumulated, input));
+            }
+
+            public Optional<A> getAccumulated() {
+                return accumulated;
+            }
+
+        }
+
+    }
+}

--- a/alloy-core/src/test/java/org/starchartlabs/alloy/test/core/collections/MoreSpliteratorsTest.java
+++ b/alloy-core/src/test/java/org/starchartlabs/alloy/test/core/collections/MoreSpliteratorsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.alloy.test.core.collections;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.mockito.Mockito;
+import org.starchartlabs.alloy.core.collections.MoreSpliterators;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class MoreSpliteratorsTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shortCircuitNullSpliterator() throws Exception {
+        MoreSpliterators.shortCircuit(null, this::accumulate, a -> a == 0);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shortCircuitNullAccumulator() throws Exception {
+        MoreSpliterators.shortCircuit(Spliterators.spliterator(new int[] { 1, 2, 3 }, 0), null, a -> (int) a == 0);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void shortCircuitNullPredicate() throws Exception {
+        MoreSpliterators.shortCircuit(Spliterators.spliterator(new int[] { 1, 2, 3 }, 0), this::accumulate, null);
+    }
+
+    @Test
+    public void shortCircuitConditionNeverMet() throws Exception {
+        Integer[] input = new Integer[] { 1, 2, 3 };
+        Spliterator<Integer> spliterator = Spliterators.spliterator(input, 0);
+
+        Spliterator<Integer> result = MoreSpliterators.shortCircuit(spliterator, this::accumulate, a -> a == 0);
+
+        Collection<Integer> traversed = StreamSupport.stream(result, false)
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(traversed.size(), 3);
+        Assert.assertTrue(traversed.containsAll(Arrays.asList(input)));
+    }
+
+    @Test
+    public void shortCircuitConditionMet() throws Exception {
+        Spliterator<Integer> spliterator = Spliterators.spliterator(new int[] { 1, 2, 0, 3 }, 0);
+
+        Spliterator<Integer> result = MoreSpliterators.shortCircuit(spliterator, this::accumulate, a -> a == 0);
+
+        // Validate inheritance of properties
+        Assert.assertNull(result.trySplit(), "Splitting not currently supported, required addition thread safety work");
+        Assert.assertEquals(spliterator.estimateSize(), result.estimateSize());
+
+        Collection<Integer> traversed = StreamSupport.stream(result, false)
+                .collect(Collectors.toList());
+
+        // Note: traversal does not end until all values necessary to fulfill the predicate have been traversed
+        Assert.assertEquals(traversed.size(), 3);
+        Assert.assertTrue(traversed.containsAll(Arrays.asList(1, 2, 0)));
+    }
+
+    @Test
+    public void shortCircuitSupportedCharacteristics() throws Exception {
+        Spliterator<?> spliterator = Mockito.mock(Spliterator.class);
+        Mockito.when(spliterator.characteristics())
+        .thenReturn(Spliterator.CONCURRENT | Spliterator.DISTINCT | Spliterator.IMMUTABLE | Spliterator.NONNULL
+                | Spliterator.ORDERED | Spliterator.SIZED | Spliterator.SORTED | Spliterator.SUBSIZED);
+
+        int expected = Spliterator.DISTINCT | Spliterator.IMMUTABLE | Spliterator.NONNULL | Spliterator.ORDERED
+                | Spliterator.SORTED;
+
+        int result = MoreSpliterators.shortCircuit(spliterator, this::accumulateMock, a -> a != null).characteristics();
+
+        // Make sure of the available options, only the intended supporting ones pass through
+        // Each of the pruned options is either violated by the nature of short-circuiting or requires additional work
+        // to support
+        Assert.assertEquals(result, expected);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void shortCircuitInheritedComparator() throws Exception {
+        Comparator<Object> expected = Mockito.mock(Comparator.class);
+        Spliterator<Object> spliterator = Mockito.mock(Spliterator.class);
+
+        Mockito.when(spliterator.getComparator()).thenReturn(expected);
+
+        Comparator<Object> result = MoreSpliterators.shortCircuit(spliterator, this::accumulateMock, a -> a != null)
+                .getComparator();
+
+        // Passing through to the underlying spliterator allows the short-circuit implementation to support the SORTED
+        // characteristic, if the underlying stream does
+        Assert.assertEquals(result, expected);
+    }
+
+    private Integer accumulate(Optional<Integer> a, Integer b) {
+        return a.map(c -> c * b).orElse(b);
+    }
+
+    private Object accumulateMock(Optional<Object> a, Object b) {
+        return b;
+    }
+
+}

--- a/dependencies.properties
+++ b/dependencies.properties
@@ -1,3 +1,5 @@
 com.google.code.findbugs:jsr305=3.0.1
 
+org.mockito:mockito-core=2.12.0
+
 org.testng:testng=6.11

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 group=org.starchartlabs.alloy
 
 # Application Versions
-version=0.3.1-SNAPSHOT
+version=0.4.0-SNAPSHOT
 
 # Consumed Language/Build System Versions
 javaVersion=1.8


### PR DESCRIPTION
Add access to a Java Spliterator implementation which allows evaluation
of previously encountered elements and ending traversal based on that
evaluation