### PR TITLE
Switch to openjdk8 for Travis Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
   
 before_install:
   - pip install --user codecov


### PR DESCRIPTION
Licensing for Oracle JDK 8 has changed, and has become unreliable for installs in Travis. Switch to openjdk8 for more stable builds