### PR TITLE
Resolves GH-57 Adds Preconditions check* calls with String formatting

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Fixed modifier order issue in org.starchartlabs.alloy.core.Comparators
 - Added org.starchartlabs.alloy.core.Preconditions.checkArgument and checkState that supports value assignment
+- (GH-57) Added integrated support for Preconditions with formatted messages
 
 ## [0.4.1]
 ### Changed

--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/Preconditions.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/Preconditions.java
@@ -199,9 +199,74 @@ public final class Preconditions {
     public static <T> T checkArgument(@Nullable T value, Predicate<T> predicate,
             Supplier<String> errorMessageSupplier) {
         Objects.requireNonNull(predicate);
+        Objects.requireNonNull(errorMessageSupplier);
 
         if (!predicate.test(value)) {
             throw new IllegalArgumentException(String.valueOf(errorMessageSupplier.get()));
+        }
+
+        return value;
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * <p>
+     * Preferred to {@link #checkArgument(boolean, Object)} when elements needs to be substituted or otherwise processed
+     * for performance reasons
+     *
+     * @param expression
+     *            A boolean expression
+     * @param template
+     *            A template for a formatted message. The message is formed by replacing each {@code %s} placeholder in
+     *            the template with an argument. These are matched by position - the first {@code %s} gets
+     *            {@code args[0]}, etc. Unmatched arguments will be appended to the formatted message in square braces.
+     *            Unmatched placeholders will be left as-is.
+     * @param args
+     *            The arguments to be substituted into the message template. Arguments are converted to strings using
+     *            {@link String#valueOf(Object)}.
+     * @throws IllegalArgumentException
+     *             If {@code expression} is false
+     * @since 0.1.0
+     */
+    public static void checkArgument(boolean expression, @Nullable String template, @Nullable Object... args) {
+        if (!expression) {
+            throw new IllegalArgumentException(String.valueOf(Strings.format(template, args)));
+        }
+    }
+
+    /**
+     * Evaluates a value against a provided {@link Predicate} expression
+     *
+     * <p>
+     * Preferred to {@link #checkArgument(Object, Predicate, Object)} when elements needs to be substituted or otherwise
+     * processed for performance reasons
+     *
+     * @param value
+     *            An assignable value to evaluate
+     * @param predicate
+     *            An operation to evaluate against {@code value}
+     * @param template
+     *            A template for a formatted message. The message is formed by replacing each {@code %s} placeholder in
+     *            the template with an argument. These are matched by position - the first {@code %s} gets
+     *            {@code args[0]}, etc. Unmatched arguments will be appended to the formatted message in square braces.
+     *            Unmatched placeholders will be left as-is.
+     * @param args
+     *            The arguments to be substituted into the message template. Arguments are converted to strings using
+     *            {@link String#valueOf(Object)}.
+     * @param <T>
+     *            The type of the value being evaluated
+     * @return {@code value} if the provided {@code predicate} evaluates to true
+     * @throws IllegalArgumentException
+     *             If {@code predicate} evaluates to false
+     * @since 0.5.0
+     */
+    public static <T> T checkArgument(@Nullable T value, Predicate<T> predicate,
+            @Nullable String template, @Nullable Object... args) {
+        Objects.requireNonNull(predicate);
+
+        if (!predicate.test(value)) {
+            throw new IllegalArgumentException(Strings.format(template, args));
         }
 
         return value;
@@ -307,7 +372,7 @@ public final class Preconditions {
      *             If {@code expression} is false
      * @since 0.1.0
      */
-    public static void checkState(boolean expression, @Nullable Supplier<String> errorMessageSupplier) {
+    public static void checkState(boolean expression, Supplier<String> errorMessageSupplier) {
         Objects.requireNonNull(errorMessageSupplier);
 
         if (!expression) {
@@ -338,9 +403,74 @@ public final class Preconditions {
      */
     public static <T> T checkState(@Nullable T value, Predicate<T> predicate, Supplier<String> errorMessageSupplier) {
         Objects.requireNonNull(predicate);
+        Objects.requireNonNull(errorMessageSupplier);
 
         if (!predicate.test(value)) {
             throw new IllegalStateException(String.valueOf(errorMessageSupplier.get()));
+        }
+
+        return value;
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * <p>
+     * Preferred to {@link #checkState(boolean, Object)} when elements needs to be substituted or otherwise processed
+     * for performance reasons
+     *
+     * @param expression
+     *            A boolean expression
+     * @param template
+     *            A template for a formatted message. The message is formed by replacing each {@code %s} placeholder in
+     *            the template with an argument. These are matched by position - the first {@code %s} gets
+     *            {@code args[0]}, etc. Unmatched arguments will be appended to the formatted message in square braces.
+     *            Unmatched placeholders will be left as-is.
+     * @param args
+     *            The arguments to be substituted into the message template. Arguments are converted to strings using
+     *            {@link String#valueOf(Object)}.
+     * @throws IllegalStateException
+     *             If {@code expression} is false
+     * @since 0.5.0
+     */
+    public static void checkState(boolean expression, @Nullable String template, @Nullable Object... args) {
+        if (!expression) {
+            throw new IllegalStateException(Strings.format(template, args));
+        }
+    }
+
+    /**
+     * Evaluates a value against a provided {@link Predicate} expression
+     *
+     * <p>
+     * Preferred to {@link #checkArgument(Object, Predicate, Object)} when elements needs to be substituted or otherwise
+     * processed for performance reasons
+     *
+     * @param value
+     *            An assignable value to evaluate
+     * @param predicate
+     *            An operation to evaluate against {@code value}
+     * @param template
+     *            A template for a formatted message. The message is formed by replacing each {@code %s} placeholder in
+     *            the template with an argument. These are matched by position - the first {@code %s} gets
+     *            {@code args[0]}, etc. Unmatched arguments will be appended to the formatted message in square braces.
+     *            Unmatched placeholders will be left as-is.
+     * @param args
+     *            The arguments to be substituted into the message template. Arguments are converted to strings using
+     *            {@link String#valueOf(Object)}.
+     * @param <T>
+     *            The type of the value being evaluated
+     * @return {@code value} if the provided {@code predicate} evaluates to true
+     * @throws IllegalStateException
+     *             If {@code predicate} evaluates to false
+     * @since 0.5.0
+     */
+    public static <T> T checkState(@Nullable T value, Predicate<T> predicate, @Nullable String template,
+            @Nullable Object... args) {
+        Objects.requireNonNull(predicate);
+
+        if (!predicate.test(value)) {
+            throw new IllegalStateException(Strings.format(template, args));
         }
 
         return value;

--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/Strings.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/Strings.java
@@ -175,7 +175,7 @@ public final class Strings {
      */
     public static String repeat(String string, int count) {
         Objects.requireNonNull(string);
-        Preconditions.checkArgument(count >= 0, () -> format("Invalid count: %s", count));
+        checkArgument(count >= 0, "Invalid count: %s", count);
 
         String result = "";
 
@@ -327,5 +327,30 @@ public final class Strings {
                 && index <= (string.length() - 2)
                 && Character.isHighSurrogate(string.charAt(index))
                 && Character.isLowSurrogate(string.charAt(index + 1));
+    }
+
+    /**
+     * Ensures the truth of an expression involving one or more parameters to the calling method.
+     *
+     * <p>
+     * Preferred to {@link #checkArgument(boolean, Object)} when elements needs to be substituted or otherwise processed
+     * for performance reasons
+     *
+     * <p>
+     * Duplicated from Preconditions to allow Preconditions to natively use Strings methods, such as {@code format},
+     * without creating a circular dependency
+     *
+     * @param expression
+     *            A boolean expression
+     * @param errorMessageSupplier
+     *            A supplier for the message to provide in the exception, if the check fails; Will not be invoked if
+     *            {@code expression} is true
+     * @throws IllegalArgumentException
+     *             If {@code expression} is false
+     */
+    private static void checkArgument(boolean expression, @Nullable String template, @Nullable Object... args) {
+        if (!expression) {
+            throw new IllegalArgumentException(format(template, args));
+        }
     }
 }

--- a/alloy-core/src/test/java/org/starchartlabs/alloy/test/core/PreconditionsTest.java
+++ b/alloy-core/src/test/java/org/starchartlabs/alloy/test/core/PreconditionsTest.java
@@ -147,6 +147,40 @@ public class PreconditionsTest {
     }
 
     @Test
+    public void checkArgumentTrueFormattedString() throws Exception {
+        Preconditions.checkArgument(true, "%s", "message");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "message")
+    public void checkArgumentFalseFormattedString() throws Exception {
+        Preconditions.checkArgument(false, "%s", "message");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void checkArgumentReturnValueStringNullPredicateFormattedString() throws Exception {
+        Preconditions.checkArgument("value", null, "%s", "message");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "message")
+    public void checkArgumentReturnValueStringFalseFormattedString() throws Exception {
+        Preconditions.checkArgument("value", t -> false, "%s", "message");
+    }
+
+    @Test
+    public void checkArgumentReturnValueNullTrueFormattedString() throws Exception {
+        Object result = Preconditions.checkArgument(null, t -> true, "%s", "message");
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void checkArgumentReturnValueStringTrueFormattedString() throws Exception {
+        Object result = Preconditions.checkArgument("value", t -> true, "%s", "message");
+
+        Assert.assertEquals(result, "value");
+    }
+
+    @Test
     public void checkStateTrue() throws Exception {
         Preconditions.checkState(true);
     }
@@ -274,6 +308,40 @@ public class PreconditionsTest {
     @Test
     public void checkStateReturnValueStringTrueSupplier() throws Exception {
         Object result = Preconditions.checkState("value", t -> true, () -> "message");
+
+        Assert.assertEquals(result, "value");
+    }
+
+    @Test
+    public void checkStateTrueFormattedString() throws Exception {
+        Preconditions.checkState(true, "%s", "message");
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "message")
+    public void checkStateFalseFormattedString() throws Exception {
+        Preconditions.checkState(false, "%s", "message");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void checkStateReturnValueStringNullPredicateFormattedString() throws Exception {
+        Preconditions.checkState("value", null, "%s", "message");
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "message")
+    public void checkStateReturnValueStringFalseFormattedString() throws Exception {
+        Preconditions.checkState("value", t -> false, "%s", "message");
+    }
+
+    @Test
+    public void checkStateReturnValueNullTrueFormattedString() throws Exception {
+        Object result = Preconditions.checkState(null, t -> true, "%s", "message");
+
+        Assert.assertNull(result);
+    }
+
+    @Test
+    public void checkStateReturnValueStringTrueFormattedString() throws Exception {
+        Object result = Preconditions.checkState("value", t -> true, "%s", "message");
 
         Assert.assertEquals(result, "value");
     }

--- a/docs/Guava-Migration.md
+++ b/docs/Guava-Migration.md
@@ -114,7 +114,7 @@ Alloy's version of ToStringBuilder does not currently overload `add` or `addValu
 ### Updated APIs
 
 - Guava Preconditions.checkArgument with message formatting
-  - Instead of the large number of Guava methods for built-in message formatting, Alloy separates out the formatting concerns using Java's Supplier via Alloy Preconditions.checkArgument(boolean, Supplier<String>). Alloy also supplies Strings.format, which replicate's Guava's Preconditions formatting behavior and performance characteristics, and can be used via lambda as a supplier
+  - Instead of the large number of Guava methods for built-in message formatting, Alloy separates out the formatting concerns using Preconditions.checkArgument(boolean, String, Object...)
   - Affected Guava Preconditions.checkArgument methods:
     - Preconditions.checkArgument(boolean, String, Object...)
     - Preconditions.checkArgument(boolean, String, char)
@@ -141,7 +141,7 @@ Alloy's version of ToStringBuilder does not currently overload `add` or `addValu
     - Preconditions.checkArgument(boolean, String, Object, Object, Object, Object)
 
 - Guava Preconditions.checkState with message formatting
-  - Instead of the large number of Guava methods for built-in message formatting, Alloy separates out the formatting concerns using Java's Supplier via Alloy Preconditions.checkState(boolean, Supplier<String>). Alloy also supplies Strings.format, which replicate's Guava's Preconditions formatting behavior and performance characteristics, and can be used via lambda as a supplier
+  - Instead of the large number of Guava methods for built-in message formatting, Alloy separates out the formatting concerns using Java's Supplier via Alloy Preconditions.checkState(boolean, String, Object...)
   - Affected Guava Preconditions.checkState methods:
     - Preconditions.checkState(boolean, String, Object...)
     - Preconditions.checkState(boolean, String, char)


### PR DESCRIPTION
This change introduces integrated methods which take a string template
and arguments for constructing exception messages. This replaces
manually creating template messages via the Preconditions Supplier-based
functions and String.format()