### PR TITLE
Resolves GH-65: Add Checkstyle validation of copyright headers

### DIFF
--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/MoreCollections.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/MoreCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 StarChart Labs Authors.
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/package-info.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/collections/package-info.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) 2018 StarChart Labs Authors.
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
+
 /**
  * Utilities for interacting with common Java collection constructs
  *

--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/package-info.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/package-info.java
@@ -1,9 +1,10 @@
 /*
- * Copyright (C) 2018 StarChart Labs Authors.
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.
  */
+
 /**
  * Core utilities for interacting with common Java constructs
  *

--- a/alloy-core/src/test/java/org/starchartlabs/alloy/test/core/collections/MoreCollectionsTest.java
+++ b/alloy-core/src/test/java/org/starchartlabs/alloy/test/core/collections/MoreCollectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 StarChart Labs Authors.
+ * Copyright (C) 2018 StarChart-Labs@github.com Authors
  *
  * This software may be modified and distributed under the terms
  * of the MIT license. See the LICENSE file for details.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -9,6 +9,11 @@
 
     <property name="fileExtensions" value="java"/>
     
+    <!-- Checks all files have a copyright header -->
+    <module name="RegexpHeader">
+   		<property name="headerFile" value="${checkstyle.config.dir}/java_copyright.header"/>
+ 	</module>
+    
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <module name="FileTabCharacter">

--- a/config/checkstyle/java_copyright.header
+++ b/config/checkstyle/java_copyright.header
@@ -1,0 +1,2 @@
+/\*$
+\W\* Copyright \(C\) \d\d\d\d StarChart-Labs@github.com Authors$


### PR DESCRIPTION
Add a Checkstyle rule to ensure all java files have the correct
copyright headers, and fix the files whose headers were inconsistent