### PR TITLE
GH-32 Update MoreObjects to be a final class

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Updated TestNG and Mockito Libraries to next major revision
+- (GH-32) Make `org.starchartlabs.alloy.core.MoreObjects` final
 
 ## [0.5.0]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ General Java utilities and quality of life tools
 
 Alloy is intended to help streamline use of common Java patterns, and reduce boilerplate code
 
+For information on migrating between major versions of Alloy, see the [migration guide](./docs/MIGRATION.md)
+
 ## Contributing
 
 Information for how to contribute to Alloy can be found in [the contribution guidelines](./docs/CONTRIBUTING.md)

--- a/alloy-core/src/main/java/org/starchartlabs/alloy/core/MoreObjects.java
+++ b/alloy-core/src/main/java/org/starchartlabs/alloy/core/MoreObjects.java
@@ -34,7 +34,14 @@ import javax.annotation.Nullable;
  * @author romeara
  * @since 0.1.0
  */
-public class MoreObjects {
+public final class MoreObjects {
+
+    /**
+     * Prevent instantiation of utility class
+     */
+    private MoreObjects() throws InstantiationException {
+        throw new InstantiationException("Cannot instantiate instance of utility class '" + getClass().getName() + "'");
+    }
 
     /**
      * Creates an instance of {@link ToStringHelper}.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,9 @@
+# Major Version Migrations
+
+This details steps for migrating between major versions of Alloy, which may contain breaking changes
+
+## 0.x to 1.x
+
+### May be Completed Prior to Upgrade
+
+- Remove any extensions of `org.starchartlabs.alloy.core.MoreObjects` - this class has been made final, as it was not intended to be extended (GH-32)


### PR DESCRIPTION
Prevent unintended extension of the utility class MoreObjects by making
the class final. This is consistent with the other utility classes
provided by the Alloy library