### PR TITLE
Only run on master commit and pull request

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: 
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Reduce duplicate status checks by only running directly on the master branch, and pull requests